### PR TITLE
Fix: Hide spinner after resources load

### DIFF
--- a/amd/src/resource_catalog.js
+++ b/amd/src/resource_catalog.js
@@ -263,6 +263,7 @@ export default class extends BaseComponent {
         const content = document.querySelector(this.selectors.content);
         if (content) {
             content.classList.remove('d-none');
+            content.classList.add('d-block'); // Ensure explicit display
         }
     }
 

--- a/amd/src/resource_catalog.js
+++ b/amd/src/resource_catalog.js
@@ -263,7 +263,7 @@ export default class extends BaseComponent {
         const content = document.querySelector(this.selectors.content);
         if (content) {
             content.classList.remove('d-none');
-            content.classList.add('d-block'); // Ensure explicit display
+            content.classList.add('d-block');
         }
     }
 

--- a/templates/resource_catalog.mustache
+++ b/templates/resource_catalog.mustache
@@ -43,9 +43,11 @@
      data-contextid="{{contextid}}"
      data-reactive="catalog">
 
-    <div class="d-flex justify-content-center my-5" id="mod-bookit-resource-spinner">
-        <div class="spinner-border text-primary" style="width: 4rem; height: 4rem;" role="status">
-            <span class="sr-only">{{#str}}loading, core{{/str}}</span>
+    <div class="d-flex justify-content-center">
+        <div class="my-5" id="mod-bookit-resource-spinner">
+            <div class="spinner-border text-primary" style="width: 4rem; height: 4rem;" role="status">
+                <span class="sr-only">{{#str}}loading, core{{/str}}</span>
+            </div>
         </div>
     </div>
 
@@ -68,4 +70,3 @@
         </div>
     </div>
 </div>
-

--- a/templates/resource_catalog_container.mustache
+++ b/templates/resource_catalog_container.mustache
@@ -32,9 +32,11 @@
      data-contextid="{{contextid}}">
 
     {{! Spinner - shown initially }}
-    <div class="d-flex justify-content-center my-5" id="mod-bookit-resource-spinner">
-        <div class="spinner-border text-primary" style="width: 4rem; height: 4rem;" role="status">
-            <span class="sr-only">{{#str}}loading, core{{/str}}</span>
+    <div class="d-flex justify-content-center">
+        <div class="my-5" id="mod-bookit-resource-spinner">
+            <div class="spinner-border text-primary" style="width: 4rem; height: 4rem;" role="status">
+                <span class="sr-only">{{#str}}loading, core{{/str}}</span>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
Fixes spinner visibility by restructuring template to match Checklist module pattern where spinner element has no display class.