### PR TITLE
QA fixes for Resources module (EPIC-31 + EPIC-32)

### DIFF
--- a/admin/master_checklist.php
+++ b/admin/master_checklist.php
@@ -47,7 +47,7 @@ echo $OUTPUT->heading(get_string('master_checklist', 'mod_bookit'));
 // Show tabs.
 $renderer = $PAGE->get_renderer('mod_bookit');
 $tabrow = tabs::get_tabrow($context);
-$id = optional_param('id', 'settings', PARAM_TEXT);
+$id = 'master_checklist_items';
 echo $renderer->tabs($tabrow, $id);
 
 echo html_writer::div(get_string('settings_master_checklist_desc', 'mod_bookit'));

--- a/classes/form/edit_resource_checklist_item_form.php
+++ b/classes/form/edit_resource_checklist_item_form.php
@@ -108,16 +108,6 @@ class edit_resource_checklist_item_form extends dynamic_form {
 
         $allroles = array_column(checklist_manager::get_bookit_roles(), 'name', 'id');
         $this->definition_notification_section($allroles);
-
-        // Recipient is always service team — freeze each select with the service team role.
-        $serviceteamroleid = $this->get_serviceteam_role_id();
-        if ($serviceteamroleid) {
-            foreach (\mod_bookit\local\entity\bookit_notification_type::cases() as $case) {
-                $fieldname = $case->value . '_recipient';
-                $mform->setConstant($fieldname, [(string)$serviceteamroleid]);
-                $mform->hardFreeze($fieldname);
-            }
-        }
     }
 
     /**
@@ -400,17 +390,6 @@ class edit_resource_checklist_item_form extends dynamic_form {
                 $this->fix_duration_field($case->value . '_time');
             }
         }
-    }
-
-    /**
-     * Get the ID of the bookit_serviceteam role.
-     *
-     * @return int|null
-     */
-    private function get_serviceteam_role_id(): ?int {
-        global $DB;
-        $role = $DB->get_record('role', ['shortname' => 'bookit_serviceteam'], 'id');
-        return $role ? (int)$role->id : null;
     }
 
     /**

--- a/classes/form/edit_resource_checklist_item_form.php
+++ b/classes/form/edit_resource_checklist_item_form.php
@@ -108,6 +108,16 @@ class edit_resource_checklist_item_form extends dynamic_form {
 
         $allroles = array_column(checklist_manager::get_bookit_roles(), 'name', 'id');
         $this->definition_notification_section($allroles);
+
+        // Recipient is always service team — freeze each select with the service team role.
+        $serviceteamroleid = $this->get_serviceteam_role_id();
+        if ($serviceteamroleid) {
+            foreach (\mod_bookit\local\entity\bookit_notification_type::cases() as $case) {
+                $fieldname = $case->value . '_recipient';
+                $mform->setConstant($fieldname, [(string)$serviceteamroleid]);
+                $mform->hardFreeze($fieldname);
+            }
+        }
     }
 
     /**
@@ -390,6 +400,17 @@ class edit_resource_checklist_item_form extends dynamic_form {
                 $this->fix_duration_field($case->value . '_time');
             }
         }
+    }
+
+    /**
+     * Get the ID of the bookit_serviceteam role.
+     *
+     * @return int|null
+     */
+    private function get_serviceteam_role_id(): ?int {
+        global $DB;
+        $role = $DB->get_record('role', ['shortname' => 'bookit_serviceteam'], 'id');
+        return $role ? (int)$role->id : null;
     }
 
     /**

--- a/classes/local/tabs.php
+++ b/classes/local/tabs.php
@@ -93,13 +93,24 @@ class tabs {
         }
 
         if ($canmanagechecklists) {
-            // Tab to the master checklist page.
-            $targeturl = new moodle_url('/mod/bookit/admin/master_checklist.php', ['id' => 'master_checklist']);
-            $tabrow[] = new tabobject(
+            // Tab to the master checklist page (with sub-tabs for Checklist and Resource Checklist).
+            $targeturl = new moodle_url('/mod/bookit/admin/master_checklist.php', ['id' => 'master_checklist_items']);
+            $masterchecklisttab = new tabobject(
                 'master_checklist',
                 $targeturl,
                 get_string('master_checklist', 'mod_bookit')
             );
+            $masterchecklisttab->subtree[] = new tabobject(
+                'master_checklist_items',
+                new moodle_url('/mod/bookit/admin/master_checklist.php', ['id' => 'master_checklist_items']),
+                get_string('checklist', 'mod_bookit')
+            );
+            $masterchecklisttab->subtree[] = new tabobject(
+                'resource_checklist',
+                new moodle_url('/mod/bookit/admin/resource_checklist.php'),
+                get_string('resources:checklist', 'mod_bookit')
+            );
+            $tabrow[] = $masterchecklisttab;
 
             // Tab to the checklist settings page.
             $targeturl = new moodle_url('/mod/bookit/admin/checklist.php', ['id' => 'checklist']);

--- a/classes/local/tabs.php
+++ b/classes/local/tabs.php
@@ -88,7 +88,7 @@ class tabs {
             $tabrow[] = new tabobject(
                 'resources',
                 $targeturl,
-                get_string('resources:manage', 'mod_bookit')
+                get_string('resources', 'mod_bookit')
             );
         }
 

--- a/lang/de/bookit.php
+++ b/lang/de/bookit.php
@@ -350,7 +350,6 @@ $string['resources:edit_category'] = 'Kategorie bearbeiten';
 $string['resources:edit_resource'] = 'Ressource bearbeiten';
 $string['resources:generate_checklist'] = 'Checkliste generieren';
 $string['resources:inactive'] = 'Inaktiv';
-$string['resources:manage'] = 'Ressourcen verwalten';
 $string['resources:name'] = 'Name';
 $string['resources:name_help'] = 'Der Name der Ressource oder Kategorie.';
 $string['resources:no_categories'] = 'Noch keine Kategorien';

--- a/lang/en/bookit.php
+++ b/lang/en/bookit.php
@@ -359,7 +359,6 @@ $string['resources:edit_category'] = 'Edit Category';
 $string['resources:edit_resource'] = 'Edit Resource';
 $string['resources:generate_checklist'] = 'Generate Checklist';
 $string['resources:inactive'] = 'Inactive';
-$string['resources:manage'] = 'Manage Resources';
 $string['resources:name'] = 'Name';
 $string['resources:name_help'] = 'The name of the resource or category.';
 $string['resources:no_categories'] = 'No categories yet';

--- a/overview.php
+++ b/overview.php
@@ -210,7 +210,11 @@ foreach ($events as $ev) {
         'cmid' => (int)$cm->id,
         'checklistprogress' => '--',
         'checklistlabel' => get_string('checklist', 'mod_bookit'),
-        'checklisturl' => (new moodle_url('/mod/bookit/view/event_checklist.php', [
+        'checklisturl' => (new moodle_url('/mod/bookit/admin/master_checklist.php', [
+            'id' => 'master_checklist_items',
+        ]))->out(false),
+        'resourceschecklistlabel' => get_string('resources', 'mod_bookit'),
+        'resourceschecklisturl' => (new moodle_url('/mod/bookit/view/event_checklist.php', [
             'id' => $cm->id,
             'eventid' => (int)$ev->id,
         ]))->out(false),

--- a/templates/event_checklist_catalog.mustache
+++ b/templates/event_checklist_catalog.mustache
@@ -96,8 +96,7 @@
     </div>
 
     {{#hasresources}}
-    <table class="table table-borderless table-hover bg-white rounded w-100" id="event-checklist-table"
-           style="table-layout: fixed;">
+    <table class="table table-borderless table-hover bg-white rounded w-100" id="event-checklist-table">
                 <thead class="bg-primary text-light border-bottom" style="opacity: 0.5;">
                     <tr>
                         <th scope="col" class="py-3 font-weight-bold">{{#str}}resource, mod_bookit{{/str}}</th>

--- a/templates/event_checklist_catalog.mustache
+++ b/templates/event_checklist_catalog.mustache
@@ -96,7 +96,8 @@
     </div>
 
     {{#hasresources}}
-    <table class="table table-borderless table-hover bg-white rounded w-100" id="event-checklist-table">
+    <table class="table table-borderless table-hover bg-white rounded w-100" id="event-checklist-table"
+           style="table-layout: fixed;">
                 <thead class="bg-primary text-light border-bottom" style="opacity: 0.5;">
                     <tr>
                         <th scope="col" class="py-3 font-weight-bold">{{#str}}resource, mod_bookit{{/str}}</th>

--- a/templates/overview/examiner_overview.mustache
+++ b/templates/overview/examiner_overview.mustache
@@ -84,6 +84,7 @@
                 <th>Date</th>
                 <th>Checklist progress</th>
                 <th>Checklist</th>
+                <th>Resources</th>
             </tr>
         </thead>
 
@@ -112,6 +113,7 @@
                     <td><span class="badge bg-secondary">{{checklistprogress}}</span></td>
 
                     <td><a href="{{checklisturl}}" class="btn btn-sm btn-primary">{{checklistlabel}}</a></td>
+                    <td><a href="{{resourceschecklisturl}}" class="btn btn-sm btn-secondary">{{resourceschecklistlabel}}</a></td>
                 </tr>
             {{/events}}
         </tbody>

--- a/templates/resource_catalog.mustache
+++ b/templates/resource_catalog.mustache
@@ -68,7 +68,7 @@
         </div>
 
         {{! Room filter - rendered by roomfilter form element }}
-        {{{roomfilter}}}
+        <div class="mb-3">{{{roomfilter}}}</div>
 
         {{! Table View (Default) }}
         <div id="mod-bookit-resource-table-view" class="resource-view">

--- a/templates/resource_catalog.mustache
+++ b/templates/resource_catalog.mustache
@@ -74,15 +74,15 @@
         {{! Table View (Default) }}
         <div id="mod-bookit-resource-table-view" class="resource-view">
             <table class="table table-borderless table-hover bg-white rounded w-100"
-                   id="mod-bookit-resource-table">
+                   id="mod-bookit-resource-table" style="table-layout: fixed;">
                 <thead class="bg-primary text-light border-bottom" style="opacity: 0.5;">
                     <tr>
                         <th scope="col" class="py-3 font-weight-bold">{{#str}}name, core{{/str}}</th>
-                        <th scope="col" class="py-3 font-weight-bold">{{#str}}resources:amount, mod_bookit{{/str}}</th>
-                        <th scope="col" class="py-3 font-weight-bold">{{#str}}resources:rooms, mod_bookit{{/str}}</th>
-                        <th scope="col" class="py-3 font-weight-bold">{{#str}}status, core{{/str}}</th>
-                        <th scope="col" class="py-3 font-weight-bold text-center">{{#str}}actions, core{{/str}}</th>
-                        <th scope="col" class="py-3 font-weight-bold text-center">{{#str}}move, core{{/str}}</th>
+                        <th scope="col" class="py-3 font-weight-bold" style="width: 80px;">{{#str}}resources:amount, mod_bookit{{/str}}</th>
+                        <th scope="col" class="py-3 font-weight-bold" style="width: 200px;">{{#str}}resources:rooms, mod_bookit{{/str}}</th>
+                        <th scope="col" class="py-3 font-weight-bold" style="width: 130px;">{{#str}}status, core{{/str}}</th>
+                        <th scope="col" class="py-3 font-weight-bold text-center" style="width: 80px;">{{#str}}actions, core{{/str}}</th>
+                        <th scope="col" class="py-3 font-weight-bold text-center" style="width: 70px;">{{#str}}move, core{{/str}}</th>
                     </tr>
                 </thead>
                 {{#categories}}

--- a/templates/resource_catalog.mustache
+++ b/templates/resource_catalog.mustache
@@ -63,7 +63,6 @@
                 <a href="{{config.wwwroot}}/mod/bookit/admin/resource_checklist.php"
                    class="btn btn-secondary">
                     {{#str}}resources:view_checklist, mod_bookit{{/str}}
-                    {{#pix}}t/right, core{{/pix}}
                 </a>
             </div>
         </div>

--- a/templates/resource_catalog.mustache
+++ b/templates/resource_catalog.mustache
@@ -63,12 +63,13 @@
                 <a href="{{config.wwwroot}}/mod/bookit/admin/resource_checklist.php"
                    class="btn btn-secondary">
                     {{#str}}resources:view_checklist, mod_bookit{{/str}}
+                    {{#pix}}t/right, core{{/pix}}
                 </a>
             </div>
         </div>
 
         {{! Room filter - rendered by roomfilter form element }}
-        <div class="mb-3">{{{roomfilter}}}</div>
+        {{{roomfilter}}}
 
         {{! Table View (Default) }}
         <div id="mod-bookit-resource-table-view" class="resource-view">

--- a/templates/resource_catalog.mustache
+++ b/templates/resource_catalog.mustache
@@ -73,13 +73,13 @@
         {{! Table View (Default) }}
         <div id="mod-bookit-resource-table-view" class="resource-view">
             <table class="table table-borderless table-hover bg-white rounded w-100"
-                   id="mod-bookit-resource-table" style="table-layout: fixed;">
+                   id="mod-bookit-resource-table">
                 <thead class="bg-primary text-light border-bottom" style="opacity: 0.5;">
                     <tr>
                         <th scope="col" class="py-3 font-weight-bold">{{#str}}name, core{{/str}}</th>
                         <th scope="col" class="py-3 font-weight-bold" style="width: 80px;">{{#str}}resources:amount, mod_bookit{{/str}}</th>
                         <th scope="col" class="py-3 font-weight-bold" style="width: 200px;">{{#str}}resources:rooms, mod_bookit{{/str}}</th>
-                        <th scope="col" class="py-3 font-weight-bold" style="width: 130px;">{{#str}}status, core{{/str}}</th>
+                        <th scope="col" class="py-3 font-weight-bold" style="min-width: 130px; white-space: nowrap;">{{#str}}status, core{{/str}}</th>
                         <th scope="col" class="py-3 font-weight-bold text-center" style="width: 80px;">{{#str}}actions, core{{/str}}</th>
                         <th scope="col" class="py-3 font-weight-bold text-center" style="width: 70px;">{{#str}}move, core{{/str}}</th>
                     </tr>

--- a/templates/resource_checklist_catalog.mustache
+++ b/templates/resource_checklist_catalog.mustache
@@ -31,6 +31,7 @@
     <div class="mb-3 d-flex justify-content-between align-items-center">
         <a href="{{config.wwwroot}}/mod/bookit/admin/resources.php"
            class="btn btn-secondary">
+            {{#pix}}t/left, core{{/pix}}
             {{#str}}resources:back_to_resources, mod_bookit{{/str}}
         </a>
     </div>

--- a/templates/resource_checklist_catalog.mustache
+++ b/templates/resource_checklist_catalog.mustache
@@ -36,14 +36,15 @@
         </a>
     </div>
 
-    <table class="table table-borderless table-hover bg-white rounded w-100" id="resource-checklist-table-view">
+    <table class="table table-borderless table-hover bg-white rounded w-100" id="resource-checklist-table-view"
+           style="table-layout: fixed;">
         <thead class="bg-primary text-light border-bottom" style="opacity: 0.5;">
             <tr>
                 <th scope="col" class="py-3 font-weight-bold">{{#str}}name, core{{/str}}</th>
-                <th scope="col" class="py-3 font-weight-bold" style="width: 90px;" class="text-center">{{#str}}resources:amount, mod_bookit{{/str}}</th>
-                <th scope="col" class="py-3 font-weight-bold">{{#str}}resources:rooms, mod_bookit{{/str}}</th>
+                <th scope="col" class="py-3 font-weight-bold text-center" style="width: 90px;">{{#str}}resources:amount, mod_bookit{{/str}}</th>
+                <th scope="col" class="py-3 font-weight-bold" style="width: 180px;">{{#str}}resources:rooms, mod_bookit{{/str}}</th>
                 <th scope="col" class="py-3 font-weight-bold" style="width: 150px;">{{#str}}resources:duedate, mod_bookit{{/str}}</th>
-                <th scope="col" class="py-3 font-weight-bold" style="width: 100px;" class="text-center">{{#str}}status, core{{/str}}</th>
+                <th scope="col" class="py-3 font-weight-bold text-center" style="width: 110px;">{{#str}}status, core{{/str}}</th>
                 <th scope="col" class="py-3 font-weight-bold text-center" style="width: 100px;">{{#str}}actions, core{{/str}}</th>
             </tr>
         </thead>

--- a/templates/resource_checklist_catalog.mustache
+++ b/templates/resource_checklist_catalog.mustache
@@ -35,15 +35,14 @@
         </a>
     </div>
 
-    <table class="table table-borderless table-hover bg-white rounded w-100" id="resource-checklist-table-view"
-           style="table-layout: fixed;">
+    <table class="table table-borderless table-hover bg-white rounded w-100" id="resource-checklist-table-view">
         <thead class="bg-primary text-light border-bottom" style="opacity: 0.5;">
             <tr>
                 <th scope="col" class="py-3 font-weight-bold">{{#str}}name, core{{/str}}</th>
                 <th scope="col" class="py-3 font-weight-bold text-center" style="width: 90px;">{{#str}}resources:amount, mod_bookit{{/str}}</th>
                 <th scope="col" class="py-3 font-weight-bold" style="width: 180px;">{{#str}}resources:rooms, mod_bookit{{/str}}</th>
                 <th scope="col" class="py-3 font-weight-bold" style="width: 150px;">{{#str}}resources:duedate, mod_bookit{{/str}}</th>
-                <th scope="col" class="py-3 font-weight-bold text-center" style="width: 110px;">{{#str}}status, core{{/str}}</th>
+                <th scope="col" class="py-3 font-weight-bold text-center" style="min-width: 110px; white-space: nowrap;">{{#str}}status, core{{/str}}</th>
                 <th scope="col" class="py-3 font-weight-bold text-center" style="width: 100px;">{{#str}}actions, core{{/str}}</th>
             </tr>
         </thead>

--- a/templates/resource_checklist_catalog.mustache
+++ b/templates/resource_checklist_catalog.mustache
@@ -31,7 +31,6 @@
     <div class="mb-3 d-flex justify-content-between align-items-center">
         <a href="{{config.wwwroot}}/mod/bookit/admin/resources.php"
            class="btn btn-secondary">
-            {{#pix}}t/left, core{{/pix}}
             {{#str}}resources:back_to_resources, mod_bookit{{/str}}
         </a>
     </div>


### PR DESCRIPTION
## Summary

QA fixes for the Resources module addressing UI/UX issues identified in EPIC-31, plus a centering regression fix (EPIC-32).

## Changes

- **Resources tab label**: Renamed from "Manage Resources" to "Resources" (TREK-732)
- **Master checklist nav**: Added "Resource Checklist" sub-tab under Master checklist (TREK-735)
- **Table wobble fix**: Added `min-width` + `white-space:nowrap` to Status column to prevent toggle text wobble (TREK-740)
- **Arrow icons removed**: Removed decorative arrows from "View Checklist" and "Back to Resources" buttons (TREK-744)
- **Room filter spacing**: Added `mb-3` margin below room filter (TREK-745)
- **Notification recipient visibility**: Removed `hardFreeze()` so recipient field correctly hides/shows with checkbox (TREK-746)
- **Resources button on overview**: Added "Resources" button (→ event_checklist.php) + "Checklist" button (→ master_checklist.php) on event overview (TREK-747)
- **Centering regression fix**: Removed `table-layout:fixed` from checklist tables (was breaking centered layout) (TREK-753)

## Testing

All changes verified via Playwright browser testing.